### PR TITLE
Fix lazy sequences

### DIFF
--- a/src/clojupyter/protocol/mime_convertible.clj
+++ b/src/clojupyter/protocol/mime_convertible.clj
@@ -13,7 +13,7 @@
 (extend-protocol PMimeConvertible
   Object
   (to-mime [o]
-    (stream-to-string {:text/plain (str o)}))
+    (stream-to-string {:text/plain (pr-str o)}))
 
   nil
   (to-mime [o]

--- a/test/clojupyter/protocol/mime_convertible_test.clj
+++ b/test/clojupyter/protocol/mime_convertible_test.clj
@@ -1,0 +1,25 @@
+(ns clojupyter.protocol.mime-convertible-test
+  (:require [clojupyter.protocol.mime-convertible :refer :all]
+            [midje.sweet :refer :all]))
+
+(fact "Should render strings, keywords, and numbers"
+      (to-mime 1) => "{\"text/plain\":\"1\"}"
+      (to-mime "2") => "{\"text/plain\":\"\\\"2\\\"\"}"
+      (to-mime :1) => "{\"text/plain\":\":1\"}"
+      (to-mime ::1) =>
+        "{\"text/plain\":\":clojupyter.protocol.mime-convertible-test/1\"}")
+
+(fact "Should render lazy sequences"
+      (to-mime (map inc [1 2 3])) => "{\"text/plain\":\"(2 3 4)\"}"
+      (to-mime (map keyword ["a" "b" "c"])) => "{\"text/plain\":\"(:a :b :c)\"}")
+
+
+(deftype Custom [])
+
+(defmethod print-method Custom
+  [v ^java.io.Writer w]
+  (.write w "my-custom"))
+
+(fact "Should render deftype toString"
+      (to-mime (Custom.)) => "{\"text/plain\":\"my-custom\"}")
+


### PR DESCRIPTION
Current head will show `clojure.lang.LazySeq@...` for expressions which yield lazy sequences (see issue #39). This PR fixes the issue by replacing `str` on the transport result with `pr`. The down side here is if someone makes an expression that yields too large a value, we'll render all of it. This is however consistent with Jupyter in general where you can shoot yourself in the foot with rendering a result. 

/cc @yanoyan who reminded me this was a bug