### PR TITLE
Fix stacktrace middleware

### DIFF
--- a/src/clojupyter/core.clj
+++ b/src/clojupyter/core.clj
@@ -45,7 +45,7 @@
   (require 'cider.nrepl)
   (apply nrepl.server/default-handler
          (map resolve
-              (concat (ns-resolve 'cider.nrepl 'cider-nrepl-middleware)
+              (concat (var-get (ns-resolve 'cider.nrepl 'cider-middleware))
                       clojupyter-middleware))))
 
 (defn start-nrepl-server []


### PR DESCRIPTION
Stack trace is broken in master
Looks like the middleware was not loaded properly.

This change fixes it. The unit test currently do not catch this error, I think we might want to add a test for this in the future.