### PR TITLE
Update pomegranate version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [cheshire "5.7.0"]
                  [cider/cider-nrepl "0.15.1"]
                  [clj-time "0.11.0"]
-                 [com.cemerick/pomegranate "0.3.1"]
+                 [com.cemerick/pomegranate "1.0.0"]
                  [com.taoensso/timbre "4.8.0"]
                  [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure


### PR DESCRIPTION
pomegranate was pulling in an old version of httpclient which was
causing compilation erros when using [clj-http][]. This commit bumps
pomegranate to the latest stable release.

[clj-http]: https://github.com/dakrone/clj-http