### PR TITLE
Fix BindException from nrepl-server

### DIFF
--- a/src/clojupyter/core.clj
+++ b/src/clojupyter/core.clj
@@ -16,17 +16,7 @@
             [clojure.walk :as walk]
             [taoensso.timbre :as log]
             [zeromq.zmq :as zmq])
-  (:import [java.net ServerSocket InetSocketAddress])
   (:gen-class :main true))
-
-(defn get-free-port!
-  "Get a free port. Problem?: reuse address unavailable on windows?"
-  []
-  (let [socket (ServerSocket.)
-        _ (.setReuseAddress socket true)
-        _ (.bind socket (InetSocketAddress. "127.0.0.1" 0))
-        _ (.close socket)]
-    (.getLocalPort socket)))
 
 (defn prep-config [args]
   (-> args
@@ -52,7 +42,6 @@
 
 (defn start-nrepl-server []
   (nrepl.server/start-server
-   :port (get-free-port!)
    :handler (clojupyer-nrepl-handler)))
 
 (defn exception-handler [e]

--- a/src/clojupyter/core.clj
+++ b/src/clojupyter/core.clj
@@ -16,16 +16,17 @@
             [clojure.walk :as walk]
             [taoensso.timbre :as log]
             [zeromq.zmq :as zmq])
-  (:import [java.net ServerSocket])
+  (:import [java.net ServerSocket InetSocketAddress])
   (:gen-class :main true))
 
 (defn get-free-port!
-  "Get a free port. Problem?: might be taken before I use it."
+  "Get a free port. Problem?: reuse address unavailable on windows?"
   []
-  (let [socket (ServerSocket. 0)
-        port (.getLocalPort socket)]
-    (.close socket)
-    port))
+  (let [socket (ServerSocket.)
+        _ (.setReuseAddress socket true)
+        _ (.bind socket (InetSocketAddress. "127.0.0.1" 0))
+        _ (.close socket)]
+    (.getLocalPort socket)))
 
 (defn prep-config [args]
   (-> args


### PR DESCRIPTION
get-free-port could cause address already in use exception. Ephemeral port binding is already done in nrepl-server.

Exception in thread "main" java.net.BindException: Address already in use (Bind failed)
	at java.net.PlainSocketImpl.socketBind(Native Method)
	at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
	at java.net.ServerSocket.bind(ServerSocket.java:375)
	at java.net.ServerSocket.bind(ServerSocket.java:329)
	at clojure.tools.nrepl.server$start_server.invokeStatic(server.clj:143)
	at clojure.tools.nrepl.server$start_server.doInvoke(server.clj:121)
	at clojure.lang.RestFn.invoke(RestFn.java:457)
	at clojupyter.core$start_nrepl_server.invokeStatic(core.clj:53)
	at clojupyter.core$start_nrepl_server.invoke(core.clj:52)
	at clojupyter.core$run_kernel.invokeStatic(core.clj:164)
	at clojupyter.core$run_kernel.invoke(core.clj:141)
	at clojupyter.core$_main.invokeStatic(core.clj:189)
	at clojupyter.core$_main.doInvoke(core.clj:187)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojupyter.core.main(Unknown Source)
