### PR TITLE
Support inspect_request

### DIFF
--- a/src/clojupyter/core.clj
+++ b/src/clojupyter/core.clj
@@ -69,6 +69,8 @@
                                                    socket message signer)
           "comm_open"           (comm-open-reply   zmq-comm
                                                    socket message signer)
+          "inspect_request"     (inspect-reply     zmq-comm nrepl-comm
+                                                   socket message signer)
           (do
             (log/error "Message type" msg-type "not handled yet. Exiting.")
             (log/error "Message dump:" message)

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -277,6 +277,23 @@
                          "history_reply"
                          content parent-header session-id metadata signer ident)))
 
+(defn inspect-reply-content
+  [request-content]
+  {:status "ok" :found false :metadata {}
+   :data {:echo request-content}})
+
+(defn inspect-reply
+  [zmq-comm nrepl-comm
+   socket message signer]
+  (let [parent-header (:header message)
+        metadata {}
+        content (inspect-reply-content (:content message))
+        session-id (get-in message [:header :session])
+        ident (:idents message)]
+    (send-router-message zmq-comm socket
+                         "inspect_reply"
+                         content parent-header session-id metadata signer ident)))
+
 ;; Handlers
 
 (defn execute-request-handler

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -283,15 +283,14 @@
   (let [code (:code request-content)
         cursor_pos (:cursor_pos request-content)
         sym (tokenize/token-at code cursor_pos)
-        result (str/join "\n"
-                         (-> (pnrepl/nrepl-doc nrepl-comm sym)
-                             str/split-lines
-                             rest))]
+        result (if-let [doc (pnrepl/nrepl-doc nrepl-comm sym)]
+                 (str/join "\n" (rest (str/split-lines doc)))
+                 "")]
     (if (str/blank? result)
-      {:status "ok" :found false :metadata {} :data {}})
+      {:status "ok" :found false :metadata {} :data {}}
       {:status "ok" :found true :metadata {}
        :data {:text/html (str "<pre>" result "</pre>")
-              :text/plain (str result)}}))
+              :text/plain (str result)}})))
 
 (defn inspect-reply
   [zmq-comm nrepl-comm

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -279,8 +279,9 @@
 
 (defn inspect-reply-content
   [request-content]
-  {:status "ok" :found false :metadata {}
-   :data {:echo request-content}})
+  {:status "ok" :found true :metadata {}
+   :data {:text/html "<b>G'day, mate!</b>"
+          :text/plain "G'day, mate!"}})
 
 (defn inspect-reply
   [zmq-comm nrepl-comm

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -278,17 +278,21 @@
                          content parent-header session-id metadata signer ident)))
 
 (defn inspect-reply-content
-  [request-content]
-  {:status "ok" :found true :metadata {}
-   :data {:text/html "<b>G'day, mate!</b>"
-          :text/plain "G'day, mate!"}})
+  [nrepl-comm request-content]
+  (let [code (:code request-content)
+        cursor_pos (:cursor_pos request-content)
+        sym (str "(token-at " code " " cursor_pos ")") ; FIXME
+        result (pnrepl/nrepl-doc nrepl-comm sym)]
+    {:status "ok" :found true :metadata {}
+     :data {:text/html (str "<pre>" result "</pre>")
+            :text/plain (str result)}}))
 
 (defn inspect-reply
   [zmq-comm nrepl-comm
    socket message signer]
   (let [parent-header (:header message)
         metadata {}
-        content (inspect-reply-content (:content message))
+        content (inspect-reply-content nrepl-comm (:content message))
         session-id (get-in message [:header :session])
         ident (:idents message)]
     (send-router-message zmq-comm socket

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -5,6 +5,7 @@
    [clj-time.format :as time-format]
    [clojupyter.misc.complete :as complete]
    [clojupyter.misc.history :as his]
+   [clojupyter.misc.tokenize :as tokenize]
    [clojupyter.protocol.zmq-comm :as pzmq]
    [clojupyter.protocol.nrepl-comm :as pnrepl]
    [clojure.pprint :as pp]
@@ -281,14 +282,16 @@
   [nrepl-comm request-content]
   (let [code (:code request-content)
         cursor_pos (:cursor_pos request-content)
-        sym code ; FIXME: find token at cursor_pos
-        result (pnrepl/nrepl-doc nrepl-comm sym)
-        found? (not (str/blank? result))]
-    (if found?
+        sym (tokenize/token-at code cursor_pos)
+        result (str/join "\n"
+                         (-> (pnrepl/nrepl-doc nrepl-comm sym)
+                             str/split-lines
+                             rest))]
+    (if (str/blank? result)
+      {:status "ok" :found false :metadata {} :data {}})
       {:status "ok" :found true :metadata {}
        :data {:text/html (str "<pre>" result "</pre>")
-              :text/plain (str result)}}
-      {:status "ok" :found false :metadata {} :data {}})))
+              :text/plain (str result)}}))
 
 (defn inspect-reply
   [zmq-comm nrepl-comm

--- a/src/clojupyter/misc/messages.clj
+++ b/src/clojupyter/misc/messages.clj
@@ -281,11 +281,14 @@
   [nrepl-comm request-content]
   (let [code (:code request-content)
         cursor_pos (:cursor_pos request-content)
-        sym (str "(token-at " code " " cursor_pos ")") ; FIXME
-        result (pnrepl/nrepl-doc nrepl-comm sym)]
-    {:status "ok" :found true :metadata {}
-     :data {:text/html (str "<pre>" result "</pre>")
-            :text/plain (str result)}}))
+        sym code ; FIXME: find token at cursor_pos
+        result (pnrepl/nrepl-doc nrepl-comm sym)
+        found? (not (str/blank? result))]
+    (if found?
+      {:status "ok" :found true :metadata {}
+       :data {:text/html (str "<pre>" result "</pre>")
+              :text/plain (str result)}}
+      {:status "ok" :found false :metadata {} :data {}})))
 
 (defn inspect-reply
   [zmq-comm nrepl-comm

--- a/src/clojupyter/misc/nrepl_comm.clj
+++ b/src/clojupyter/misc/nrepl_comm.clj
@@ -158,7 +158,12 @@
            (map :candidate)
            (into []))))
   (nrepl-doc [self sym]
-    (str "(doc " sym ")"))) ; FIXME
+    (let [code (str "(clojure.repl/doc " sym ")")
+          result (-> (:nrepl-client self)
+                     (nrepl/message {:op :eval
+                                     :code code})
+                     nrepl/combine-responses)]
+    (:out result))))
 
 (defn make-nrepl-comm [nrepl-server nrepl-transport
                        nrepl-client nrepl-session]

--- a/src/clojupyter/misc/nrepl_comm.clj
+++ b/src/clojupyter/misc/nrepl_comm.clj
@@ -156,7 +156,9 @@
       (->> result
            :completions
            (map :candidate)
-           (into [])))))
+           (into []))))
+  (nrepl-doc [self sym]
+    (str "(doc " sym ")"))) ; FIXME
 
 (defn make-nrepl-comm [nrepl-server nrepl-transport
                        nrepl-client nrepl-session]

--- a/src/clojupyter/misc/tokenize.clj
+++ b/src/clojupyter/misc/tokenize.clj
@@ -1,8 +1,27 @@
 (ns clojupyter.misc.tokenize
   (require [clojure.string :as string]))
 
+
+(defn re-index
+  "Returns a sorted-map of indicies to matches."
+  [re s]
+  (loop [matcher (re-matcher re s)
+         matches (sorted-map)]
+    (if (.find matcher)
+      (recur matcher
+             (assoc matches (.start matcher) (.group matcher)))
+      matches)))
+
+
 (defn token-at
   "Returns the token at the given position."
   [code position]
-  "identity")
+  (->>
+    (loop [token-pos (re-index #"\S+" code)]
+      (cond
+        (nil? (first token-pos)) nil
+        (nil? (second token-pos)) (val (first token-pos))
+        (< position (key (second token-pos))) (val (first token-pos))
+        :else (recur (rest token-pos))))
+    (re-find #"[^\(\)\{\}\[\]\"\']+")))
 

--- a/src/clojupyter/misc/tokenize.clj
+++ b/src/clojupyter/misc/tokenize.clj
@@ -1,0 +1,8 @@
+(ns clojupyter.misc.tokenize
+  (require [clojure.string :as string]))
+
+(defn token-at
+  "Returns the token at the given position."
+  [code position]
+  "identity")
+

--- a/src/clojupyter/protocol/nrepl_comm.clj
+++ b/src/clojupyter/protocol/nrepl_comm.clj
@@ -5,4 +5,5 @@
   (nrepl-interrupt [self])
   (nrepl-eval [self states zmq-comm code parent-header session-id signer ident])
   (nrepl-complete [self code])
+  (nrepl-doc [self sym])
   )


### PR DESCRIPTION
Shift-Tab sends an inspect_request to the kernel.

This brings up a tooltip with the function/macro/namespace docstring.

![identity](https://user-images.githubusercontent.com/4932496/47948724-f5214500-df0c-11e8-92c3-a5534cad78c9.png)

![string](https://user-images.githubusercontent.com/4932496/47948729-f9e5f900-df0c-11e8-9998-13b37b12b6fa.png)
