### PR TITLE
Upgrade Clojure dependency to 1.10.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure
                                                           net.cgrand.parsley]]
-                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojure "1.10.0"]
                  [org.clojure/core.async "0.2.395"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.clojure/data.json "0.2.6"]


### PR DESCRIPTION
I've been using Clojure 1.10.0 (and its pre-release versions) with this kernel on-and-off for months and things appear to be in good working order.