### PR TITLE
Feature/ipywidgets

### DIFF
--- a/examples/demo-ipywidgets.ipynb
+++ b/examples/demo-ipywidgets.ipynb
@@ -232,27 +232,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note: *How does one animate the above progress bars?*"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "(ipy/bounded-int-text {:min 0 :max 100 :step 5})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note: *The above widget acts like a bounded-float-text if we pass a float step.*\n",
-    "No longer true, now that the widgets get validated."
    ]
   },
   {

--- a/examples/interactive-widgets.ipynb
+++ b/examples/interactive-widgets.ipynb
@@ -112,7 +112,7 @@
     "(def W1\n",
     "  (let [OUT (ipy/label)\n",
     "        W (ipy/combobox {:options [\"blue\" \"black\" \"green\" \"yellow\"] :description \"Pick a color\"\n",
-    "                             :callbacks {:on-submit (fn [_] (swap! OUT assoc :value \"User submitted\"))}})]\n",
+    "                             :callbacks {:on-submit (fn [_ _ _] (swap! OUT assoc :value \"User submitted\"))}})]\n",
     "    (ipy/v-box {:children [W OUT]})))\n",
     "W1"
    ]
@@ -255,9 +255,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Clojure (clojupyter-0.3.3-snapshot-3v0.2.2-86-g3c1e-dirty)",
+   "display_name": "Clojure (clojupyter-0.3.3-snapshot)",
    "language": "clojure",
-   "name": "clojupyter-0.3.3-snapshot-3v0.2.2-86-g3c1e-dirty"
+   "name": "clojupyter-0.3.3-snapshot"
   },
   "language_info": {
    "file_extension": ".clj",

--- a/examples/interactive-widgets.ipynb
+++ b/examples/interactive-widgets.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "source": [
     "## Stateless Callbacks\n",
-    "Some widgets send on-click and on-submit callbacks which can be handled by attaching a fn of no arguments to :on-click and :on-submit respectively."
+    "Some widgets send on-click and on-submit callbacks which can be handled by attaching a fn of 3 arguments (the widget reference. the message content, and a sequence of buffers) to the `:callbacks` map `:on-click` and `:on-submit` respectively."
    ]
   },
   {
@@ -86,8 +86,10 @@
    "outputs": [],
    "source": [
     "(let [out (ipy/label)\n",
-    "      but (ipy/button {:description \"Click me\" :on-click (fn [] (swap! out assoc :value \"Button clicked\"))})]\n",
-    "  (ipy/v-box {:children [but out]}))"
+    "      out2 (ipy/label)\n",
+    "      but (ipy/button {:description \"Click me\" :callbacks {:on-click [(fn [_ _ _] (swap! out assoc :value \"Button clicked\"))\n",
+    "                                                                      (fn [_ _ _] (swap! out2 assoc :value \"Second fn ran\"))]}})]\n",
+    "  (ipy/v-box {:children [but out out2]}))"
    ]
   },
   {
@@ -97,7 +99,7 @@
    "outputs": [],
    "source": [
     "(def L0 (ipy/label))\n",
-    "(def BUTS (ipy/toggle-buttons {:options [\"one\" \"two\"] :on-click (fn [] (swap! L0 assoc :value (str \"Toggle pressed on \" (:value @BUTS))))}))\n",
+    "(def BUTS (ipy/toggle-buttons {:options [\"one\" \"two\"] :callbacks {:on-click (fn [w _ _] (swap! L0 assoc :value (str \"Toggle pressed on \" (:value @w))))}}))\n",
     "(ipy/v-box {:children [L0 BUTS]})"
    ]
   },
@@ -109,7 +111,8 @@
    "source": [
     "(def W1\n",
     "  (let [OUT (ipy/label)\n",
-    "        W (ipy/combobox {:options [\"blue\" \"black\" \"green\" \"yellow\"] :description \"Pick a color\" :on-submit (fn [] (swap! OUT assoc :value \"User submitted\"))})]\n",
+    "        W (ipy/combobox {:options [\"blue\" \"black\" \"green\" \"yellow\"] :description \"Pick a color\"\n",
+    "                             :callbacks {:on-submit (fn [_] (swap! OUT assoc :value \"User submitted\"))}})]\n",
     "    (ipy/v-box {:children [W OUT]})))\n",
     "W1"
    ]
@@ -139,14 +142,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "(def W\n",
     "(let [w0 (ipy/file-upload {:description \"Upload an image\":accept \"jpg\" :multiple true})\n",
     "      w1 (ipy/int-slider {:min 300 :max 1000 :value 400 :step 10})\n",
     "      w2 (ipy/image {:width (str (:value @w1))})\n",
     "      ww (ipy/h-box {:children [w0 w1]})\n",
     "      _ (.watch w1 :on-change (fn [_ _ o-state n-state] (when (not= (:value o-state) (:value n-state)) (swap! w2 assoc :width (str (:value n-state))))))\n",
     "      _ (.watch w0 :on-change (fn [_ _ o-state n-state] (when (not= (:value o-state) (:value n-state)) (swap! w2 assoc :value (-> n-state :value first :content)))))]\n",
-    "  (ipy/v-box {:children [ww w2]}))"
+    "  (ipy/v-box {:children [ww w2]})))W"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -233,13 +244,20 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Clojure (clojupyter-0.3.3-snapshot)",
+   "display_name": "Clojure (clojupyter-0.3.3-snapshot-3v0.2.2-86-g3c1e-dirty)",
    "language": "clojure",
-   "name": "clojupyter-0.3.3-snapshot"
+   "name": "clojupyter-0.3.3-snapshot-3v0.2.2-86-g3c1e-dirty"
   },
   "language_info": {
    "file_extension": ".clj",

--- a/src/clojupyter/kernel/comm_atom.clj
+++ b/src/clojupyter/kernel/comm_atom.clj
@@ -116,7 +116,7 @@
   mc/PMimeConvertible
   (to-mime [_]
     (u/json-str {:text/plain
-                 ,, (str "[" cid_ "]=" @comm-state_)
+                 ,, (str "[" cid_ "]=" (:_model_name @comm-state_))
                  :application/vnd.jupyter.widget-view+json
                  ,, {:version_major WIDGET-VERSION-MAJOR
                      :version_minor WIDGET-VERSION-MINOR
@@ -187,7 +187,7 @@
 
 (defn- simple-fmt
   [comm-atom]
-  (str "#<" (prefix comm-atom) (short-comm-id comm-atom) ":" @comm-atom ">"))
+  (str "#<" (prefix comm-atom) (:_model_name @comm-atom) ">"))
 
 (defn- print-prettily
   [^CommAtom comm-atom ^java.io.Writer w]
@@ -197,14 +197,12 @@
      (pp/pprint-logical-block
        (print (prefix comm-atom))
        (pp/pprint-newline :linear)
-       (pp/pprint-logical-block (pp/write @comm-atom :length 100)))
+       (pp/pprint-logical-block (pp/write @comm-atom)))
      (print ">"))))
 
 (defmethod print-method CommAtom
   [^CommAtom comm-atom ^java.io.Writer w]
-  (if pp/*print-pretty*
-    (print-prettily comm-atom w)
-    (.write w ^String (simple-fmt comm-atom))))
+  (.write w ^String (simple-fmt comm-atom)))
 
 (defmethod pp/simple-dispatch CommAtom
   [^CommAtom comm-atom]

--- a/src/clojupyter/kernel/core.clj
+++ b/src/clojupyter/kernel/core.clj
@@ -97,9 +97,9 @@
    (C (wrap-skip-shutdown-tokens
        (C (fn [krsp] (extract-kernel-response-byte-arrays krsp))
           (fn [krsp] (replace-comm-atoms-with-references krsp))
-          (fn [krsp] (msgs/kernelrsp->jupmsg port signer krsp))))
+          (fn [krsp] (msgs/kernelrsp->jupmsg port krsp))))
       (logging-transducer (str "OUTBOUND:" port))
-      (wrap-skip-shutdown-tokens (fn [jupmsg] (msgs/jupmsg->frames jupmsg))))))
+      (wrap-skip-shutdown-tokens (fn [jupmsg] (msgs/jupmsg->frames signer jupmsg))))))
 
 (defn- start-zmq-socket-forwarding
   "Starts threads forwarding traffic between ZeroMQ sockets and core.async channels.  Returns a

--- a/src/clojupyter/log.clj
+++ b/src/clojupyter/log.clj
@@ -5,6 +5,8 @@
             [io.simplect.compose :refer [def- c C p P]]
             [taoensso.timbre :as timbre]))
 
+(def ^:dynamic *verbose* false)
+
 (defmacro debug
   [& args]
   `(timbre/debug ~@args))

--- a/src/clojupyter/log.clj
+++ b/src/clojupyter/log.clj
@@ -63,7 +63,8 @@
 
 (def CONFIG {:timestamp-opts {:pattern "HH:mm:ss.SSS", :locale :jvm-default, :timezone :utc}
              :ns-blacklist ["io.pedestal.*"]
-             :output-fn output-fn})
+             :output-fn output-fn
+             :level :warn})
 
 (defn- set-clojupyter-config!
   []
@@ -76,6 +77,6 @@
 (defn init!
   []
   (set-clojupyter-config!)
-  (timbre/set-level! (cfg/log-level)))
+  #_(timbre/set-level! (cfg/log-level)))
 
 (init!) ;; avoid spurious debug messages from io.pedestal when loading with midje testing turned on

--- a/src/clojupyter/util_actions.clj
+++ b/src/clojupyter/util_actions.clj
@@ -103,8 +103,9 @@
     (let [action-result (leave-action {})]
       (if (a/success? action-result)
         (assoc result :leave-action action-result)
-        (throw (ex-info (str "Action failed: " action-result)
-                 {:action leave-action, :action-result action-result}))))
+        (do (log/warn "Action failed: " (pr-str (.failure action-result)))
+            (when log/*verbose* (log/warn {:action leave-action, :action-result action-result}))
+            result)))
     result))
 
 (defmacro  exiting-on-completion

--- a/src/clojupyter/util_actions.clj
+++ b/src/clojupyter/util_actions.clj
@@ -103,7 +103,7 @@
     (let [action-result (leave-action {})]
       (if (a/success? action-result)
         (assoc result :leave-action action-result)
-        (do (log/warn "Action failed: " (pr-str (.failure action-result)))
+        (do (log/error "Action failed: " (pr-str (.failure action-result)))
             (when log/*verbose* (log/warn {:action leave-action, :action-result action-result}))
             result)))
     result))
@@ -241,6 +241,5 @@
       (catch Exception e
         (log/error e)
         (Thread/sleep 10)
-        [return-value (str e) e])))))
-
+        (assoc return-value :error e))))))
 (set-defn-indent! #'exiting-on-completion #'without-exiting #'with-temp-directory!)

--- a/test/clojupyter/messages_tests.clj
+++ b/test/clojupyter/messages_tests.clj
@@ -21,7 +21,7 @@
   (prop/for-all [{:keys [msgtype content]} mg/g-jupmsg-content-any]
     (let [jupmsg (merge ((sh/s*message-header msgtype) content))]
       (and (s/valid? ::jsp/jupmsg jupmsg)
-           (s/valid? ::msp/frames (msgs/jupmsg->frames jupmsg))))))
+           (s/valid? ::msp/frames (msgs/jupmsg->frames (constantly "-SIGNED-") jupmsg))))))
 
 (fact
  "Jupyter protocol frames can be generated from jupmsgs"
@@ -33,7 +33,7 @@
     (prop/for-all [{:keys [msgtype content]} mg/g-jupmsg-content-any]
       (let [checker (constantly true)
             jupmsg (merge ((sh/s*message-header msgtype {:signature sig}) content))
-            frames(msgs/jupmsg->frames jupmsg)
+            frames(msgs/jupmsg->frames (constantly "-SIGNATURE-") jupmsg)
             jupmsg' (msgs/frames->jupmsg checker frames)]
         (and (apply = (mapv (P dissoc :preframes :buffers) [jupmsg jupmsg']))
              (= [(into [] (-> jupmsg :preframes .-envelope))


### PR DESCRIPTION
Three main changes:
1. Added *verbose* variable to control printing large amount of data such as comms global state.
2. Updated custom msg callback fn signature to accept 3 vars, the widget, the message content, and buffers.
3. Updated the leave action handler to log failures at warning level instead of throwing exception and stopping the dispatch loop. As a result, failures on message or fn callbacks no longer reset the kernel, but notify the user of failure in the logs. Also updated default log level to `:warn` to show the errors by default.
**Later edit:**
The list of changes has grown:
4. Custom msg callback fn now accepts 3 arguments.
5. Improved error handling: the message dispatch loop no longer stops at error but instead prints the error to log and continues. It raises the errors listed at no.3 to error level.
6. Improved performance of rendering and notebook file size by preventing the widgets from printing its state to string.
7. Fixed bug in message signing and checking of jupyter messages.