### PR TITLE
fix: Use /usr/bin/env which

### DIFF
--- a/src/clojupyter/util_actions.clj
+++ b/src/clojupyter/util_actions.clj
@@ -124,7 +124,7 @@
 
 (defmulti  find-executable (fn [_] (os/operating-system)))
 (letfn [(find-exe [exe]
-          (let [{:keys [out err exit]} (sh/sh "/usr/bin/which" exe)]
+          (let [{:keys [out err exit]} (sh/sh "/usr/bin/env which" exe)]
             (when (zero? exit)
               (-> out str/trim io/file)))) ]
   (defmethod find-executable :macos [exe]


### PR DESCRIPTION
This breaks packaging on nixos because /usr/bin isn't a thing. 