### PR TITLE
Fix signing in lab 3.x & update some quite old deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,12 +1,12 @@
 {:paths ["src" "resources"]
  :deps {
 	camel-snake-kebab		{:mvn/version "0.4.0"}
-	cheshire			{:mvn/version "5.8.1"}
-	cider/cider-nrepl		{:mvn/version "0.21.1"}
+	cheshire			{:mvn/version "5.10.0"}
+	cider/cider-nrepl		{:mvn/version "0.26.0"}
 	clojure.java-time		{:mvn/version "0.3.2"}
 	com.cemerick/pomegranate	{:mvn/version "1.1.0"}
 	com.grammarly/omniconf		{:mvn/version "0.3.2"}
-	com.taoensso/timbre		{:mvn/version "4.10.0"}
+	com.taoensso/timbre		{:mvn/version "5.1.2"}
 	hiccup				{:mvn/version "1.0.5"}
         io.aviso/pretty			{:mvn/version "0.1.33"}
 	io.forward/yaml			{:mvn/version "1.0.9" :exclusions [org.flatland/ordered]}
@@ -19,7 +19,7 @@
 	nrepl				{:mvn/version "0.6.0"}
 	org.clojure/clojure		{:mvn/version "1.10.1"}
 	org.clojure/data.codec		{:mvn/version "0.1.1"}
-	org.clojure/data.json		{:mvn/version "0.2.6"}
+	org.clojure/data.json		{:mvn/version "2.3.1"}
 	org.clojure/java.jdbc		{:mvn/version "0.7.9"}
 	org.clojure/test.check		{:mvn/version "0.10.0-RC1"}
 	org.clojure/tools.cli		{:mvn/version "0.4.2"}
@@ -29,7 +29,7 @@
 	pandect				{:mvn/version "0.6.1"}
 	slingshot			{:mvn/version "0.12.2"}
 	zprint				{:mvn/version "0.4.15"}
-        org.clojure/core.async		{:mvn/version "0.4.500"}
+        org.clojure/core.async		{:mvn/version "1.3.618"}
         ,,
         com.fzakaria/slf4j-timbre	{:mvn/version "0.3.14"}
         org.slf4j/log4j-over-slf4j	{:mvn/version "1.7.14"}

--- a/src/clojupyter/messages.clj
+++ b/src/clojupyter/messages.clj
@@ -283,7 +283,7 @@
           preframes (make-jupmsg-preframes envelope delim signature)
           body-map (parse-json-and-build-jupmsg (select-keys strbody [:header :parent-header :metadata :content]))
           jupmsg (assoc body-map :preframes preframes :buffers buffers)]
-      (when-not (check-signature jupmsg)
+      (when-not (check-signature strbody signature)
         (let [msg "Invalid message signature"]
           (log/error msg)
          (throw (Exception. msg))))
@@ -349,7 +349,7 @@
          envelope	(if (= rsp-socket :iopub_port)
                           [(u/get-bytes rsp-msgtype)]
                           (message-envelope req-message))
-         signature	(u/get-bytes (signer [header parent-header metadata rsp-content]))]
+         signature	(u/get-bytes (signer (map u/json-str [header parent-header metadata rsp-content])))]
      (make-jupmsg envelope signature header parent-header metadata rsp-content rsp-buffers))))
 
 ;;; ------------------------------------------------------------------------------------------------------------------------
@@ -614,5 +614,3 @@
   (s/cat :data ::data, :metadata ::metadata, :transient ::transient)
   [data metadata tsient]
   {:data data, :metadata metadata, :transient tsient})
-
-

--- a/src/clojupyter/util.clj
+++ b/src/clojupyter/util.clj
@@ -164,15 +164,14 @@
 (defn make-signer-checker
   [key]
   (let [mkchecker (fn mkchecker [signer]
-                    (fn [{:keys [header parent-header metadata content preframes]}]
+                    (fn [{:keys [header parent-header metadata content]} signature]
                       (let [payload-vec [header parent-header metadata content]
-                            signature (.-signature preframes)
                             check-signature (signer payload-vec)]
                         (= check-signature (bytes->string* signature)))))
         signer	(if (empty? key)
                   (constantly "")
                   (fn signer [payload-vec]
-                    (sha256-hmac (apply str (map json-str* payload-vec)) key)))]
+                    (sha256-hmac (apply str payload-vec) key)))]
     [signer (mkchecker signer)]))
 
 (redefn parse-json-str cheshire/parse-string)

--- a/src/clojupyter/util_actions.clj
+++ b/src/clojupyter/util_actions.clj
@@ -124,7 +124,7 @@
 
 (defmulti  find-executable (fn [_] (os/operating-system)))
 (letfn [(find-exe [exe]
-          (let [{:keys [out err exit]} (sh/sh "/usr/bin/env which" exe)]
+          (let [{:keys [out err exit]} (sh/sh "/usr/bin/env" "which" exe)]
             (when (zero? exit)
               (-> out str/trim io/file)))) ]
   (defmethod find-executable :macos [exe]


### PR DESCRIPTION
Fixes #134 by not depending on first parsing the message body and then signing the re-serialized body. As mentioned in #134 this depends on identical map->json serialization in the kernel and the jupyter lab frontend (which broke/changed in the most recent version of jupyter lab - and maybe all versions 3.x).

This PR
- changes the parameters to the signer to be a seq of strings rather than a seq of maps; this enables us to check the signature of the message without depending on fully parsing the message body

In addition, we upgrade some quite old dependencies, and fix a bad invocation of `(sh/sh "/usr/bin/env which" exe)` to `(sh/sh "/usr/bin/env" "which" exe)` (which may fail in some cases).