### PR TITLE
Clojure 1.11.1 and support latest lab

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,38 +1,32 @@
 {:paths ["src" "resources"]
  :deps {
-	camel-snake-kebab		{:mvn/version "0.4.0"}
-	cheshire			{:mvn/version "5.10.0"}
-	cider/cider-nrepl		{:mvn/version "0.26.0"}
-	clojure.java-time		{:mvn/version "0.3.2"}
+	cheshire			{:mvn/version "5.11.0"}
+	clojure.java-time		{:mvn/version "1.1.0"}
 	com.cemerick/pomegranate	{:mvn/version "1.1.0"}
-	com.grammarly/omniconf		{:mvn/version "0.3.2"}
+	com.grammarly/omniconf	{:mvn/version "0.4.3"}
 	com.taoensso/timbre		{:mvn/version "5.1.2"}
 	hiccup				{:mvn/version "2.0.0-alpha2"}
-        io.aviso/pretty			{:mvn/version "0.1.33"}
-	io.forward/yaml			{:mvn/version "1.0.9" :exclusions [org.flatland/ordered]}
-	io.pedestal/pedestal.interceptor {:mvn/version "0.5.7"}
+	io.pedestal/pedestal.interceptor {:mvn/version "0.5.10"}
 	io.simplect/compose		{:mvn/version "0.7.27"}
 	me.raynes/fs			{:mvn/version "1.4.6"}
 	net.cgrand/parsley		{:mvn/version "0.9.3" :exclusions [org.clojure/clojure]}
 	net.cgrand/regex		{:mvn/version "1.1.0" :exclusions [org.clojure/clojure]}
 	net.cgrand/sjacket		{:mvn/version "0.1.1" :exclusions [org.clojure/clojure net.cgrand.parsley]}
-	nrepl				{:mvn/version "0.6.0"}
-	org.clojure/clojure		{:mvn/version "1.10.1"}
+	nrepl				{:mvn/version "1.0.0"}
+	org.clojure/clojure		{:mvn/version "1.11.1"}
 	org.clojure/data.codec		{:mvn/version "0.1.1"}
-	org.clojure/data.json		{:mvn/version "2.3.1"}
-	org.clojure/java.jdbc		{:mvn/version "0.7.9"}
-	org.clojure/test.check		{:mvn/version "0.10.0-RC1"}
-	org.clojure/tools.cli		{:mvn/version "0.4.2"}
-	org.flatland/ordered		{:mvn/version "1.5.7"}
-	org.xerial/sqlite-jdbc		{:mvn/version "3.36.0.3"}
-	org.zeromq/jeromq		{:mvn/version "0.5.1"}
-	pandect				{:mvn/version "0.6.1"}
+	org.clojure/data.json		{:mvn/version "2.4.0"}
+	org.clojure/java.jdbc		{:mvn/version "0.7.12"}
+	org.clojure/test.check		{:mvn/version "1.1.1"}
+	org.clojure/tools.cli		{:mvn/version "1.0.206"}
+	org.xerial/sqlite-jdbc		{:mvn/version "3.39.3.0"}
+	org.zeromq/jeromq		{:mvn/version "0.5.2"}
+	pandect				{:mvn/version "1.0.2"}
 	slingshot			{:mvn/version "0.12.2"}
-	zprint				{:mvn/version "0.4.15"}
-        org.clojure/core.async		{:mvn/version "1.3.618"}
-        ,,
-        com.fzakaria/slf4j-timbre	{:mvn/version "0.3.14"}
-        org.slf4j/log4j-over-slf4j	{:mvn/version "1.7.14"}
-        org.slf4j/jul-to-slf4j		{:mvn/version "1.7.14"}
-        org.slf4j/jcl-over-slf4j	{:mvn/version "1.7.14"}
+	zprint				{:mvn/version "1.2.4"}
+        org.clojure/core.async		{:mvn/version "1.5.648"}
+        com.fzakaria/slf4j-timbre	{:mvn/version "0.3.21"}
+        org.slf4j/log4j-over-slf4j	{:mvn/version "2.0.3"}
+        org.slf4j/jul-to-slf4j		{:mvn/version "2.0.3"}
+        org.slf4j/jcl-over-slf4j	{:mvn/version "2.0.3"}
 	}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,13 @@
 {:paths ["src" "resources"]
  :deps {
 	cheshire			{:mvn/version "5.11.0"}
+	cider/cider-nrepl  {:mvn/version "0.26.0"}
 	clojure.java-time		{:mvn/version "1.1.0"}
 	com.cemerick/pomegranate	{:mvn/version "1.1.0"}
 	com.grammarly/omniconf	{:mvn/version "0.4.3"}
 	com.taoensso/timbre		{:mvn/version "5.1.2"}
 	hiccup				{:mvn/version "2.0.0-alpha2"}
+        io.forward/yaml                 {:mvn/version "1.0.11" :exclusions [org.flatland/ordered]}
 	io.pedestal/pedestal.interceptor {:mvn/version "0.5.10"}
 	io.simplect/compose		{:mvn/version "0.7.27"}
 	me.raynes/fs			{:mvn/version "1.4.6"}
@@ -28,5 +30,5 @@
         com.fzakaria/slf4j-timbre	{:mvn/version "0.3.21"}
         org.slf4j/log4j-over-slf4j	{:mvn/version "2.0.3"}
         org.slf4j/jul-to-slf4j		{:mvn/version "2.0.3"}
-        org.slf4j/jcl-over-slf4j	{:mvn/version "2.0.3"}
-	}}
+        org.slf4j/jcl-over-slf4j	{:mvn/version "2.0.3"}}
+ }

--- a/deps.edn
+++ b/deps.edn
@@ -1,20 +1,20 @@
 {:paths ["src" "resources"]
  :deps {
-	cheshire			{:mvn/version "5.11.0"}
+	cheshire/cheshire			{:mvn/version "5.11.0"}
 	cider/cider-nrepl  {:mvn/version "0.26.0"}
-	clojure.java-time		{:mvn/version "1.1.0"}
+	clojure.java-time/clojure.java-time		{:mvn/version "1.1.0"}
 	com.cemerick/pomegranate	{:mvn/version "1.1.0"}
 	com.grammarly/omniconf	{:mvn/version "0.4.3"}
 	com.taoensso/timbre		{:mvn/version "5.1.2"}
-	hiccup				{:mvn/version "2.0.0-alpha2"}
+	hiccup/hiccup				{:mvn/version "2.0.0-alpha2"}
         io.forward/yaml                 {:mvn/version "1.0.11" :exclusions [org.flatland/ordered]}
 	io.pedestal/pedestal.interceptor {:mvn/version "0.5.10"}
 	io.simplect/compose		{:mvn/version "0.7.27"}
 	me.raynes/fs			{:mvn/version "1.4.6"}
 	net.cgrand/parsley		{:mvn/version "0.9.3" :exclusions [org.clojure/clojure]}
 	net.cgrand/regex		{:mvn/version "1.1.0" :exclusions [org.clojure/clojure]}
-	net.cgrand/sjacket		{:mvn/version "0.1.1" :exclusions [org.clojure/clojure net.cgrand.parsley]}
-	nrepl				{:mvn/version "1.0.0"}
+	net.cgrand/sjacket		{:mvn/version "0.1.1" :exclusions [org.clojure/clojure net.cgrand/parsley]}
+	nrepl/nrepl				{:mvn/version "1.0.0"}
 	org.clojure/clojure		{:mvn/version "1.11.1"}
 	org.clojure/data.codec		{:mvn/version "0.1.1"}
 	org.clojure/data.json		{:mvn/version "2.4.0"}
@@ -23,9 +23,10 @@
 	org.clojure/tools.cli		{:mvn/version "1.0.206"}
 	org.xerial/sqlite-jdbc		{:mvn/version "3.39.3.0"}
 	org.zeromq/jeromq		{:mvn/version "0.5.2"}
-	pandect				{:mvn/version "1.0.2"}
-	slingshot			{:mvn/version "0.12.2"}
-	zprint				{:mvn/version "1.2.4"}
+	pandect/pandect				{:mvn/version "1.0.2"}
+        org.clojure/tools.analyzer      {:mvn/version "1.1.0"}
+	slingshot/slingshot			{:mvn/version "0.12.2"}
+	zprint/zprint				{:mvn/version "1.2.4"}
         org.clojure/core.async		{:mvn/version "1.5.648"}
         com.fzakaria/slf4j-timbre	{:mvn/version "0.3.21"}
         org.slf4j/log4j-over-slf4j	{:mvn/version "2.0.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,11 @@
 	clojure.java-time/clojure.java-time		{:mvn/version "1.1.0"}
 	com.cemerick/pomegranate	{:mvn/version "1.1.0"}
 	com.grammarly/omniconf	{:mvn/version "0.4.3"}
-	com.taoensso/timbre		{:mvn/version "5.1.2"}
+	com.taoensso/timbre		{:mvn/version "5.2.1"}
+	io.aviso/pretty 		{:mvn/version "1.1.1"}
 	hiccup/hiccup				{:mvn/version "2.0.0-alpha2"}
         io.forward/yaml                 {:mvn/version "1.0.11" :exclusions [org.flatland/ordered]}
+	org.flatland/ordered {:mvn/version "1.15.10"}
 	io.pedestal/pedestal.interceptor {:mvn/version "0.5.10"}
 	io.simplect/compose		{:mvn/version "0.7.27"}
 	me.raynes/fs			{:mvn/version "1.4.6"}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject clojupyter "0.3.3-SNAPSHOT"
-  :description                  "A Jupyter kernel for Clojure"
-  :license                      {:name "MIT"}
-  :url                          "https://github.com/clojupyter/clojupyter"
+(defproject clojupyter "0.3.6-SNAPSHOT"
+  :description			"A Jupyter kernel for Clojure"
+  :license			{:name "MIT"}
+  :url				"https://github.com/clojupyter/clojupyter"
 
 
   :scm                          {:name "git" :url "https://github.com/clojupyter/clojupyter"}

--- a/resources/clojupyter/assets/version.edn
+++ b/resources/clojupyter/assets/version.edn
@@ -1,1 +1,1 @@
-{:version "0.3.3-SNAPSHOT"}
+{:version "0.3.6-SNAPSHOT"}

--- a/src/clojupyter/kernel/handle_event_process.clj
+++ b/src/clojupyter/kernel/handle_event_process.clj
@@ -61,10 +61,16 @@
               (run-dispatch-loop sock-kw valid-msgtype-pred ctx))
         (log/debug (str "handle-event-process terminating: "  sock-kw))))))
 
-(def valid-control-port-msgtype? (p contains? #{msgs/SHUTDOWN-REQUEST msgs/INTERRUPT-REQUEST}))
+(def valid-control-port-msgtype? (p contains? #{msgs/SHUTDOWN-REQUEST msgs/INTERRUPT-REQUEST msgs/KERNEL-INFO-REQUEST}))
+
+(defn valid-shell-port-msgtype?
+  [msg]
+  (or
+   (not (valid-control-port-msgtype? msg))
+   (contains? #{msgs/KERNEL-INFO-REQUEST} msg)))
 
 (defn start-handle-event-process
   [ctx]
   (doseq [[sock-kw pred] [[:control_port 	valid-control-port-msgtype?]
-                          [:shell_port		(complement valid-control-port-msgtype?)]]]
+                          [:shell_port		valid-shell-port-msgtype?]]]
     (start-channel-thread sock-kw pred ctx)))

--- a/src/clojupyter/log.clj
+++ b/src/clojupyter/log.clj
@@ -57,6 +57,7 @@
 
 (def CONFIG {:timestamp-opts {:pattern "HH:mm:ss.SSS", :locale :jvm-default, :timezone :utc}
              :ns-blacklist ["io.pedestal.*"]
+
              :output-fn output-fn})
 
 (defn- set-clojupyter-config!

--- a/src/clojupyter/messages.clj
+++ b/src/clojupyter/messages.clj
@@ -13,7 +13,7 @@
             [clojure.walk :as walk]
             [io.simplect.compose :refer [C def- fmap p P sdefn >->> >>->]]))
 
-(def PROTOCOL-VERSION "5.2")
+(def PROTOCOL-VERSION "5.3")
 
 
 ;;; ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates all deps to better support 1.11.1 (note that not all deps have 1.11.1 support so there is future work here)

- Fix-up bad handling of comms_open with widgets
- Bump protocol to 5.3 (no handling of Kernel interrupt but also not needed)
- This also supports Mac M1 (tested with reasonably new jupyter* and Mac M1 Max)

Closing #163 #162 #160 #159 #146 #142 

Note for Conda users: right now the only supported installation path is via clojars or via building locally. At the moment, I don't have the knowledge or bandwidth to support installation of clojupyter via conda.



