### PR TITLE
bump openjdk version to the latest and remove maven requirement

### DIFF
--- a/src/clojupyter/install/conda/yaml.clj
+++ b/src/clojupyter/install/conda/yaml.clj
@@ -12,7 +12,7 @@
 (def DEPEND [csp/DEPEND-DUMMY])
 
 (def- JUP-DEPS ["ipywidgets" "jupyterlab" "notebook" "qtconsole" "widgetsnbextension"])
-(def- BUILD-DEPS ["openjdk=8" "maven"])
+(def- BUILD-DEPS ["openjdk"])
 (def- RUN-DEPS	(vec (concat BUILD-DEPS JUP-DEPS)))
 
 (def unqualify-kws (p walk/postwalk (u/call-if keyword? (C name keyword))))


### PR DESCRIPTION
It seems like the`BUILD-DEPS` requiring `openjdk=8` and `maven` for conda are a bit dated.

`maven` would probably be implicit from `lein` being the builder anyway.

So .. loosening the `BUILD-DEPS` to just `openjdk` allows for the following to succeed
    
    export BUILDNUM=2
    make conda-build
    lein clojupyter install

..which allows the start of `jupyter notebook` both from the command line and from Anaconda.