### PR TITLE
Update timbre dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         clojure.java-time/clojure.java-time     {:mvn/version "1.1.0"}
         clj-commons/pomegranate {:mvn/version "1.2.23"}
         com.grammarly/omniconf  {:mvn/version "0.4.3"}
-        com.taoensso/timbre     {:mvn/version "5.2.1"}
+        com.taoensso/timbre     {:mvn/version "6.4.0"}
         io.aviso/pretty         {:mvn/version "1.1.1"}
         hiccup/hiccup               {:mvn/version "2.0.0-RC2"}
         io.forward/yaml                 {:mvn/version "1.0.11" :exclusions [org.flatland/ordered]}


### PR DESCRIPTION
this fixes the errors i'm getting for

```
Caused by: clojure.lang.ArityException: Wrong number of args (12) passed to: taoensso.timbre/-log!
        at clojure.lang.AFn.throwArity(AFn.java:429)
        at clojure.lang.AFn.invoke(AFn.java:82)
```

## alternate approaches
I tried excluding timbre and manually installing this version timbre but kept running into

```
Caused by: Syntax error macroexpanding taoensso.encore/defalias at (taoensso/encore.cljc:711:6).
[encore/defalias] Failed to resolve source var for sym: taoensso.truss/with-data
```

