### PR TITLE
support headless

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -67,7 +67,8 @@
   (write-pom!)
   (b/compile-clj {:basis basis
                   :src-dirs ["src"]
-                  :class-dir class-dir}))
+                  :class-dir class-dir
+                  :java-opts  ["-Djava.awt.headless=true"] }))
 
 (defn jar [_]
   (build-common)

--- a/deps.edn
+++ b/deps.edn
@@ -47,6 +47,7 @@
          :extra-deps {midje/midje {:mvn/version "1.10.10"}
                       org.scicloj/noj {:mvn/version "2-beta4"} ;; to test all kinds
                       }
+         :jvm-opts ["-Djava.awt.headless=true"]
          :exec-fn clojupyter.run-tests/run-tests-and-exit}
 
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}

--- a/deps.edn
+++ b/deps.edn
@@ -40,6 +40,7 @@
  {:build
   {:deps
    {io.github.clojure/tools.build {:mvn/version "0.10.6"}}
+   
    :ns-default build}
 
   :test {:extra-paths ["test"]

--- a/src/clojupyter/util.clj
+++ b/src/clojupyter/util.clj
@@ -135,7 +135,7 @@
 
 (defn kernel-spec
   [dest-jar kernel-id-string]
-  {:argv ["java" "-cp" (str dest-jar) "clojupyter.kernel.core" "{connection_file}"]
+  {:argv ["java" "-Djava.awt.headless=true" "-cp" (str dest-jar) "clojupyter.kernel.core" "{connection_file}"]
    :display_name (kernel-full-identifier kernel-id-string)
    :language "clojure"
    :interrupt_mode "message"})


### PR DESCRIPTION
its a follow-up change from #190 

To work from a devcontainer either requires this change
or to install certain xwindows libraries in the devcontainer.

Boht are valid options and should have no impact on clojupyter behavoiur.

Please decide what you prefer