### PR TITLE
Add clojupyter.cmdline "file" option to run a Clojure file

### DIFF
--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -334,8 +334,8 @@ The example is analogue to the `eval` option:
 ```
 where the Clojure file `hello.clj` has e.g. the following content:
 ```
-(print "Hello ")
-(print "Jupyter!\n")
+(defn -main [args]
+  (println "Hello Jupyter!"))
 ```
 
 ### `list-installs`

--- a/doc/command-line.md
+++ b/doc/command-line.md
@@ -15,6 +15,8 @@ Clojupyter kernel using Anaconda, see [Conda-installing Clojupyter](conda-instal
   * [help](#help)
   * [install](#install)
   * [list-commands](#list-commands)
+  * [eval](#eval)
+  * [file](#file)
   * [list-installs-matching](#list-installs-matching)
   * [list-installs](#list-installs)
   * [remove-install](#remove-install)
@@ -304,6 +306,36 @@ Clojupyter v0.2.3 - List commands
 
 exit(0)
 >
+```
+
+### `eval`
+
+Evaluate a Clojure expression.
+
+Example (assume that from [clojupyter/releases](https://github.com/clojupyter/clojupyter/releases), you download the file `clojupyter-<VERSION>.jar`, where`<VERSION>` stands for your choice, e.g. `0.5.424-SNAPSHOT-standalone`)
+```
+> java -cp target/clojupyter-0.5.424-SNAPSHOT-standalone.jar clojupyter.cmdline eval '(str "Hello " "Jupyter!")'
+Clojupyter v0.5.424-SNAPSHOT@424 - EVAL
+
+       (str "Hello " "Jupyter!") => 
+       
+       "Hello Jupyter!"
+
+exit(0)
+```
+
+### `file`
+
+Run a Clojure file.
+
+The example is analogue to the `eval` option:
+```
+> java -cp target/clojupyter-0.5.424-SNAPSHOT-standalone.jar clojupyter.cmdline file hello.clj
+```
+where the Clojure file `hello.clj` has e.g. the following content:
+```
+(print "Hello ")
+(print "Jupyter!\n")
 ```
 
 ### `list-installs`

--- a/src/clojupyter/cmdline.clj
+++ b/src/clojupyter/cmdline.clj
@@ -60,6 +60,13 @@
        (cmdline/outputs res)
        (cmdline/set-exit-code 0))))
 
+(defn- s*file
+  [name]
+  (s*eval (str "(do \n"
+               (try (slurp name)
+                    (catch Throwable e (str "Error: " e)))
+               ")")))
+
 (defn- s*getenv
   [env-var]
   (C (cmdline/set-header "GETENV")
@@ -374,6 +381,8 @@
   {"help"           [nil s*help]
    "install"            [nil s*install]
    "list-commands"      [0 (s*list-commands CMDS)]
+   "eval"               [1 s*eval]
+   "file"               [1 s*file]
    "list-installs"      [0 s*list-installs]
    "list-installs-matching" [1 s*list-installs-matching 1
                              "Usage: Specify a regular expression to match with kernel identifier."]
@@ -388,7 +397,6 @@
   {"conda-build"        [nil s*conda-build]     ;; Build package for distribution via conda
    "conda-link"         [nil s*conda-link]      ;; Used by conda install procedure on end-user machine
    "conda-unlink"       [nil s*conda-unlink]        ;; Used by conda uninastall procedure on end-user machine
-   "eval"           [1 s*eval]          ;; For debugging
    "getenv"         [1 s*getenv]            ;; For debugging
    "list-dvl-commands"      [0 (s*list-commands DVL-CMDS)]  ;; In case you forget
    "supported-os?"      [0 s*supported-os?]     ;; Not really used

--- a/src/clojupyter/cmdline.clj
+++ b/src/clojupyter/cmdline.clj
@@ -60,12 +60,7 @@
        (cmdline/outputs res)
        (cmdline/set-exit-code 0))))
 
-(defn- s*file
-  [name]
-  (s*eval (str "(do \n"
-               (try (slurp name)
-                    (catch Throwable e (str "Error: " e)))
-               ")")))
+(defn- s*file [name] (load-file name))
 
 (defn- s*getenv
   [env-var]


### PR DESCRIPTION
This PR  is just a suggestion, to make a point. I am aware that running a file cuts across the original Clojupyter idea, because it has nothing to do with Jupyter per se. Also the implementation itself is a hack, a proof of concept.

The target audience for such a `file` option would be Python coders (scientists, non-developers) who just want to play around with Clojure before adding the Clojure kernel to their Jupyter. It is meant to lower the entry bar.

As said, this is more an idea, an argument. For concreteness in the disguise of a PR.